### PR TITLE
Conservative compatibility hack for joblib import

### DIFF
--- a/Example.ipynb
+++ b/Example.ipynb
@@ -21,7 +21,6 @@
     "from sklearn.gaussian_process import kernels\n",
     "from sklearn.decomposition import PCA\n",
     "from sklearn.preprocessing import StandardScaler\n",
-    "from sklearn.externals import joblib\n",
     "\n",
     "import matplotlib.cm as cm\n",
     "import matplotlib.pyplot as plt\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ h5py
 hic
 numpy
 PyYAML
+joblib
 scikit-learn>=0.18
 scipy
 pandas

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import re
 import sys
 import pickle
-from sklearn.externals import joblib
 
 logging.basicConfig(
     stream=sys.stdout,

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -17,8 +17,13 @@ import logging
 import pickle
 
 import numpy as np
+
+try:                                      # compatibility hack: first try to import joblib the deprecated way
+    from sklearn.externals import joblib  # raises an ImportError if sklearn.externals.joblib is not found
+except ImportError:                       # if that failed, then try to import joblib the correct way
+    import joblib                         # this shouldn't fail, but if it does, run 'pip install joblib scikit-learn --user' to resolve
+
 from sklearn.decomposition import PCA
-from sklearn.externals import joblib
 from sklearn.gaussian_process import GaussianProcessRegressor as GPR
 from sklearn.gaussian_process import kernels
 from sklearn.preprocessing import StandardScaler

--- a/src/mcmc.py
+++ b/src/mcmc.py
@@ -32,7 +32,6 @@ import emcee
 import h5py
 import numpy as np
 from scipy.linalg import lapack
-from sklearn.externals import joblib
 from . import workdir, systems, observables, exp_data_list, exp_cov#, expt
 from .design import Design
 from .emulator import emulators

--- a/src/plots.py
+++ b/src/plots.py
@@ -24,7 +24,6 @@ import subprocess
 import tempfile
 import warnings
 
-from sklearn.externals import joblib
 import h5py
 import hsluv
 import numpy as np


### PR DESCRIPTION
sklearn.externals.joblib was deprecated in 0.21 and removed in 0.23 (12 May 2020); the code should be updated to `import joblib` specifically, but this hack will attempt the deprecated approach first, just in case the new approach doesn't work in anyone's current environment.